### PR TITLE
[BUG] Found BUSL-1.1 in place of an MIT LICENSE

### DIFF
--- a/src/SafeCounter.sol
+++ b/src/SafeCounter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.21;
 
 import "./interfaces/ISafeCounterImplementor.sol";

--- a/src/interfaces/ISafeCounterHookReceiver.sol
+++ b/src/interfaces/ISafeCounterHookReceiver.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.21;
 
 interface ISafeCounterHookReceiver {

--- a/src/interfaces/ISafeCounterImplementor.sol
+++ b/src/interfaces/ISafeCounterImplementor.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.21;
 
 interface ISafeCounterImplementor {


### PR DESCRIPTION
### Describe the bug
It seems that a BUSL-1.1 LICENSE has been added by mistake.

### Expected Behavior
To fix this bug, change all instances of

```diff
- BUSL-1.1
+ MIT
```

### To Reproduce
No response

### Additional context
No response