### PR TITLE
Use Chainalysis sanctions list oracle

### DIFF
--- a/src/Chainalysis.sol
+++ b/src/Chainalysis.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.21;
+
+import "./interfaces/ISanctionsList.sol";
+
+error SanctionedAddress(address actor);
+error SanctionsListNotSupported(uint256 chainId);
+
+ISanctionsList constant SanctionsList = ISanctionsList(0x40C57923924B5c5c5455c48D93317139ADDaC8fb);
+
+/**
+ * @dev The "magic" modulus 13 is used to reduce each 2 byte chain id
+ *      to something that can be used as an offset into a lookup table
+ *      with a reasonable size in memory. Each supported chain id is
+ *      stored at byte `(chainId % 13) * 2`.
+ *
+ *      ==============================================
+ *      | Network         | Position (chainId % 13)  |
+ *      ==============================================
+ *      | Mainnet         | 0x01 % 13 = 1            |
+ *      | Arbitrum        | 0xa4b1 % 13 = 2          |
+ *      | Fantom          | 0xfa % 13 = 3            |
+ *      | BNB Smart Chain | 0x38 % 13 = 4            |
+ *      | Avalanche       | 0xa86a % 13 = 6          |
+ *      | Polygon         | 0x89 % 13 = 7            |
+ *      | Celo            | 0xa4ec % 13 = 9          |
+ *      | Optimism        | 0x0a % 13 = 10           |
+ *      ==============================================
+ */
+uint256 constant ChainIdLookupTable = (0x0001 << 16) | (0xa4b1 << 32) | (0x00fa << 48) | (0x0038 << 64) | (0xa86a << 96)
+    | (0x0089 << 112) | (0xa4ec << 144) | (0x000a << 160);
+
+// Checks whether the Chainalysis sanctions list is deployed
+// on the current chain.
+function isSanctionsListSupported(uint256 chainId) pure returns (bool supportedChainId) {
+    assembly {
+        // Lookup `chainId % 13` in the lookup table and verify it matches
+        // the chainId.
+        supportedChainId := eq(chainId, and(0xffff, shr(shl(4, mod(chainId, 13)), ChainIdLookupTable)))
+    }
+}
+
+// Checks if an address is on a sanctions list according to Chainalysis.
+function isSanctioned(address account) view returns (bool) {
+    if (!isSanctionsListSupported(block.chainid)) {
+        revert SanctionsListNotSupported(block.chainid);
+    }
+    return SanctionsList.isSanctioned(account);
+}

--- a/src/Chainalysis.sol
+++ b/src/Chainalysis.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.21;
 
 import "./interfaces/ISanctionsList.sol";

--- a/src/SafeCounter.sol
+++ b/src/SafeCounter.sol
@@ -13,7 +13,16 @@ struct SafeCounter {
     mapping(address => bool) __blockList;
 }
 
-using {increment, safeIncrement, decrement, safeDecrement, current, isBlocked, requireNotBlocked, sanction} for SafeCounter global;
+using {
+    increment,
+    safeIncrement,
+    decrement,
+    safeDecrement,
+    current,
+    isBlocked,
+    requireNotBlocked,
+    sanction
+} for SafeCounter global;
 
 function current(SafeCounter storage counter) view returns (uint256) {
     return counter.__inner;

--- a/src/SafeCounter.sol
+++ b/src/SafeCounter.sol
@@ -3,42 +3,24 @@ pragma solidity ^0.8.21;
 
 import "./interfaces/ISafeCounterImplementor.sol";
 import "./interfaces/ISafeCounterHookReceiver.sol";
+import "./Chainalysis.sol";
 
 error Overflow(uint256 count);
 error Underflow(uint256 count);
-error Blocklist(address actor);
 
 struct SafeCounter {
     uint256 __inner;
     mapping(address => bool) __blockList;
 }
 
-using {
-    increment,
-    safeIncrement,
-    decrement,
-    safeDecrement,
-    current,
-    isBlocked,
-    requireNotBlocked,
-    sanction
-} for SafeCounter global;
+using {increment, safeIncrement, decrement, safeDecrement, current, requireNotSanctioned} for SafeCounter global;
 
 function current(SafeCounter storage counter) view returns (uint256) {
     return counter.__inner;
 }
 
-function isBlocked(SafeCounter storage counter, address account) view returns (bool) {
-    return counter.__blockList[account];
-}
-
-function requireNotBlocked(SafeCounter storage counter, address account) view returns (SafeCounter storage) {
-    if (counter.isBlocked(account)) revert Blocklist(account);
-    return counter;
-}
-
-function sanction(SafeCounter storage counter, address account) returns (SafeCounter storage) {
-    counter.__blockList[account] = true;
+function requireNotSanctioned(SafeCounter storage counter, address account) view returns (SafeCounter storage) {
+    if (isSanctioned(account)) revert SanctionedAddress(account);
     return counter;
 }
 
@@ -47,7 +29,7 @@ function increment(SafeCounter storage counter) returns (SafeCounter storage) {
 }
 
 function safeIncrement(SafeCounter storage counter, ISafeCounterHookReceiver receiver) returns (SafeCounter storage) {
-    requireNotBlocked(counter, msg.sender);
+    requireNotSanctioned(counter, msg.sender);
     if (counter.__inner == type(uint256).max) revert Overflow(counter.current());
     counter.__inner += 1;
     receiver.onIncrement(counter.current() - 1, counter.current());
@@ -60,7 +42,7 @@ function decrement(SafeCounter storage counter) returns (SafeCounter storage) {
 }
 
 function safeDecrement(SafeCounter storage counter, ISafeCounterHookReceiver receiver) returns (SafeCounter storage) {
-    requireNotBlocked(counter, msg.sender);
+    requireNotSanctioned(counter, msg.sender);
     if (counter.current() == 0) revert Underflow(counter.current());
     counter.__inner -= 1;
     receiver.onIncrement(counter.current() + 1, counter.current());

--- a/src/SafeCounter.sol
+++ b/src/SafeCounter.sol
@@ -10,7 +10,6 @@ error Underflow(uint256 count);
 
 struct SafeCounter {
     uint256 __inner;
-    mapping(address => bool) __blockList;
 }
 
 using {increment, safeIncrement, decrement, safeDecrement, current, requireNotSanctioned} for SafeCounter global;

--- a/src/interfaces/ISanctionsList.sol
+++ b/src/interfaces/ISanctionsList.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.21;
+
+interface ISanctionsList {
+    function isSanctioned(address addr) external view returns (bool);
+}

--- a/src/interfaces/ISanctionsList.sol
+++ b/src/interfaces/ISanctionsList.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.21;
 
 interface ISanctionsList {

--- a/test/Chainalysis.t.sol
+++ b/test/Chainalysis.t.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.21;
+
+import "forge-std/Test.sol";
+import "../src/Chainalysis.sol" as Chainalysis;
+import "./mock/MockSanction.sol";
+
+contract ChainalysisWrapper {
+    function isSanctioned(address addr) external view returns (bool) {
+        return Chainalysis.isSanctioned(addr);
+    }
+}
+
+contract CounterTest is Test {
+    MockSanction mockSanction;
+    uint256[8] internal SupportedChainIds = [0x01, 0xa4b1, 0xfa, 0x38, 0xa86a, 0x89, 0xa4ec, 0x0a];
+    ChainalysisWrapper internal chainalysis;
+
+    function setUp() public {
+        vm.etch(address(SanctionsList), type(MockSanction).runtimeCode);
+        mockSanction = MockSanction(address(SanctionsList));
+    }
+
+    function testFuzzIsOfacCompliant(address sanctionedEntity) public {
+        mockSanction.complyWithOfac(sanctionedEntity);
+        vm.expectRevert(abi.encodePacked(SanctionsListNotSupported.selector, uint256(block.chainid)));
+    }
+
+    function testIsSanctionsListSupported() public {
+        for (uint256 i; i < 8; i++) {
+            assertEq(Chainalysis.isSanctionsListSupported(SupportedChainIds[i]), true);
+        }
+    }
+
+    function testIsSanctioned(address sanctionedEntity) public {
+        vm.expectRevert(abi.encodePacked(SanctionsListNotSupported.selector, uint256(block.chainid)));
+        chainalysis.isSanctioned(sanctionedEntity);
+
+        vm.chainId(SupportedChainIds[0]);
+        assertEq(Chainalysis.isSanctioned(sanctionedEntity), false);
+        mockSanction.complyWithOfac(sanctionedEntity);
+        assertEq(Chainalysis.isSanctioned(sanctionedEntity), true);
+    }
+}

--- a/test/SafeCounter.t.sol
+++ b/test/SafeCounter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.21;
 
 import "forge-std/Test.sol";
 import "../src/SafeCounter.sol";
@@ -10,7 +10,8 @@ contract CounterTest is Test {
     SafeCounter public counter;
 
     function setUp() public {
-        mockSanction = new MockSanction();
+        vm.etch(address(SanctionsList), type(MockSanction).runtimeCode);
+        mockSanction = MockSanction(address(SanctionsList));
     }
 
     function testIncrement() public {

--- a/test/mock/MockSanction.sol
+++ b/test/mock/MockSanction.sol
@@ -4,13 +4,9 @@ pragma solidity ^0.8.21;
 import "../../src/SafeCounter.sol";
 
 contract MockSanction {
-    SafeCounter internal counter;
+    mapping(address => bool) public isSanctioned;
 
     function complyWithOfac(address actor) public {
-        counter.sanction(actor);
-    }
-
-    function incrementSafeCounter() public {
-        counter.increment();
+        isSanctioned[actor] = true;
     }
 }


### PR DESCRIPTION
Replaced block list with Chainalysis sanctions oracle. Reverts when called on chain without a Chainalysis deployment.